### PR TITLE
fix error in render module

### DIFF
--- a/aPyOpenGL/agl/render.py
+++ b/aPyOpenGL/agl/render.py
@@ -195,7 +195,7 @@ class Render:
     
     @staticmethod
     def skeleton(pose: Pose, render_mode="pbr"):
-        skeleton_xforms = pose.skeleton_xforms()
+        skeleton_xforms = pose.skeleton_xforms
 
         ro = Render.pyramid(radius=1, height=1, render_mode=render_mode).instance_num(pose.skeleton.num_joints - 1)
 


### PR DESCRIPTION
resolves TypeError: 'numpy.ndarray' object is not callable:
`aPyOpenGL/aPyOpenGL/agl/render.py", line 198, in skeleton
    skeleton_xforms = pose.skeleton_xforms()
`
